### PR TITLE
Add govuk-lint

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,2 @@
+AllCops:
+  TargetRubyVersion: 2.3

--- a/Gemfile
+++ b/Gemfile
@@ -2,10 +2,13 @@ source 'https://rubygems.org'
 
 ruby File.read(".ruby-version").strip
 
-gem 'govuk_schemas', '~> 0.1'
+gem 'govuk_schemas', '~> 2.1.0'
 gem 'sinatra', '~> 1.4'
 gem 'http', '~> 2.0'
 gem 'activesupport', '~> 4.2'
 
-gem 'rspec', '~> 3.4'
-gem 'rack-test', '~> 0.6.3'
+group :development, :test do
+  gem 'govuk-lint'
+  gem 'rspec', '~> 3.4'
+  gem 'rack-test', '~> 0.6.3'
+end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,12 +8,15 @@ GEM
       thread_safe (~> 0.3, >= 0.3.4)
       tzinfo (~> 1.1)
     addressable (2.3.8)
+    ast (2.3.0)
     diff-lcs (1.2.5)
     domain_name (0.5.20160826)
       unf (>= 0.0.5, < 1.0.0)
-    govuk_schemas (0.1.0)
-      activesupport
-      json-schema
+    govuk-lint (1.2.1)
+      rubocop (~> 0.39.0)
+      scss_lint
+    govuk_schemas (2.1.0)
+      json-schema (~> 2.5.0)
     http (2.0.3)
       addressable (~> 2.3)
       http-cookie (~> 1.0)
@@ -25,14 +28,19 @@ GEM
     http_parser.rb (0.6.0)
     i18n (0.7.0)
     json (1.8.3)
-    json-schema (2.6.2)
+    json-schema (2.5.2)
       addressable (~> 2.3.8)
     minitest (5.9.0)
+    parser (2.4.0.0)
+      ast (~> 2.2)
+    powerpack (0.1.1)
     rack (1.6.4)
     rack-protection (1.5.3)
       rack
     rack-test (0.6.3)
       rack (>= 1.0)
+    rainbow (2.2.1)
+    rake (12.0.0)
     rspec (3.5.0)
       rspec-core (~> 3.5.0)
       rspec-expectations (~> 3.5.0)
@@ -46,6 +54,17 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.5.0)
     rspec-support (3.5.0)
+    rubocop (0.39.0)
+      parser (>= 2.3.0.7, < 3.0)
+      powerpack (~> 0.1)
+      rainbow (>= 1.99.1, < 3.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (~> 1.0, >= 1.0.1)
+    ruby-progressbar (1.8.1)
+    sass (3.4.23)
+    scss_lint (0.52.0)
+      rake (>= 0.9, < 13)
+      sass (~> 3.4.20)
     sinatra (1.4.7)
       rack (~> 1.5)
       rack-protection (~> 1.4)
@@ -57,13 +76,15 @@ GEM
     unf (0.1.4)
       unf_ext
     unf_ext (0.0.7.2)
+    unicode-display_width (1.1.3)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
   activesupport (~> 4.2)
-  govuk_schemas (~> 0.1)
+  govuk-lint
+  govuk_schemas (~> 2.1.0)
   http (~> 2.0)
   rack-test (~> 0.6.3)
   rspec (~> 3.4)


### PR DESCRIPTION
This commit adds govuk-lint to this project. It also updates the version of `govuk_schemas` to fix a test failure.